### PR TITLE
pico lan speed-up

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -30,9 +30,6 @@
 
 #include "debug.h"
 #include "sdc.h"
-#if defined(PICO_RP2040) || defined(PICO_RP2350)
-#include "tusb_asix/asix_host.h"
-#endif
 
 #include "ftpd.h"
 
@@ -433,36 +430,18 @@ static void do_stor(ftps_t *fs, const char *path)
 
     bool ok = true;
     uint32_t total = restart_at;        /* track offset to pinpoint a bad write */
-    uint32_t recv_calls = 0;
-    uint32_t write_calls = 0;
-    uint32_t max_recv = 0;
-    TickType_t recv_ticks = 0;
-    TickType_t write_ticks = 0;
-#if defined(PICO_RP2040) || defined(PICO_RP2350)
-    uint32_t asix_before[ASIX_STAT_COUNT];
-    uint32_t asix_after[ASIX_STAT_COUNT];
-    tuh_asix_get_stats(asix_before);
-#endif
     for (;;) {
-        TickType_t t0 = xTaskGetTickCount();
         int r = lwip_recv(dfd, fs->xbuf, XFER_CHUNK, 0);
-        recv_ticks += xTaskGetTickCount() - t0;
-        recv_calls++;
         if (r == 0)
             break;
         if (r < 0) {
             ok = false;
             break;
         }
-        if ((uint32_t)r > max_recv)
-            max_recv = (uint32_t)r;
         UINT bw = 0;
         sdc_lock();
-        t0 = xTaskGetTickCount();
         FRESULT wr = f_write(&f, fs->xbuf, (UINT)r, &bw);
-        write_ticks += xTaskGetTickCount() - t0;
         sdc_unlock();
-        write_calls++;
         if (wr != FR_OK || bw != (UINT)r) {
             debugf("FTP: STOR write failed at offset %lu (recv=%d written=%u fr=%d)",
                    (unsigned long)total, r, bw, wr);
@@ -473,36 +452,10 @@ static void do_stor(ftps_t *fs, const char *path)
     }
 
     sdc_lock();
-    TickType_t close_start = xTaskGetTickCount();
     f_close(&f);
-    TickType_t close_ticks = xTaskGetTickCount() - close_start;
     sdc_unlock();
     lwip_close(dfd);
     reply(fs, ok ? "226 Transfer complete." : "426 Transfer aborted.");
-#if defined(PICO_RP2040) || defined(PICO_RP2350)
-    tuh_asix_get_stats(asix_after);
-#endif
-    if (ok) {
-        debugf("FTP: STORED %s (%lu bytes, recv calls=%lu max=%lu, recv=%lu ms write=%lu ms close=%lu ms writes=%lu)",
-               path, (unsigned long)total, (unsigned long)recv_calls, (unsigned long)max_recv,
-               (unsigned long)(recv_ticks * portTICK_PERIOD_MS),
-               (unsigned long)(write_ticks * portTICK_PERIOD_MS),
-               (unsigned long)(close_ticks * portTICK_PERIOD_MS),
-               (unsigned long)write_calls);
-#if defined(PICO_RP2040) || defined(PICO_RP2350)
-        debugf("FTP: ASIX delta rx_xfer=%lu rx_frame=%lu rx_bad=%lu rx_trunc=%lu rx_pbuf_fail=%lu tx_start=%lu tx_queue=%lu tx_full=%lu tx_fail=%lu tx_done=%lu",
-               (unsigned long)(asix_after[ASIX_STAT_RX_XFERS] - asix_before[ASIX_STAT_RX_XFERS]),
-               (unsigned long)(asix_after[ASIX_STAT_RX_FRAMES] - asix_before[ASIX_STAT_RX_FRAMES]),
-               (unsigned long)(asix_after[ASIX_STAT_RX_BAD_HEADER] - asix_before[ASIX_STAT_RX_BAD_HEADER]),
-               (unsigned long)(asix_after[ASIX_STAT_RX_TRUNCATED] - asix_before[ASIX_STAT_RX_TRUNCATED]),
-               (unsigned long)(asix_after[ASIX_STAT_RX_PBUF_FAIL] - asix_before[ASIX_STAT_RX_PBUF_FAIL]),
-               (unsigned long)(asix_after[ASIX_STAT_TX_STARTED] - asix_before[ASIX_STAT_TX_STARTED]),
-               (unsigned long)(asix_after[ASIX_STAT_TX_QUEUED] - asix_before[ASIX_STAT_TX_QUEUED]),
-               (unsigned long)(asix_after[ASIX_STAT_TX_QUEUE_FULL] - asix_before[ASIX_STAT_TX_QUEUE_FULL]),
-               (unsigned long)(asix_after[ASIX_STAT_TX_START_FAIL] - asix_before[ASIX_STAT_TX_START_FAIL]),
-               (unsigned long)(asix_after[ASIX_STAT_TX_DONE] - asix_before[ASIX_STAT_TX_DONE]));
-#endif
-    }
 }
 
 /* ---- command loop ---------------------------------------------------------- */

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -144,7 +144,7 @@
 #error "Cannot determine TinyUSB version!"
 #endif
 
-#if TUSB_VERSION_NUMBER < 1700
+#if TUSB_VERSION_NUMBER < 2000
 #error "Please update your TinyUSB installation!"
 #endif
 

--- a/src/tusb_asix/asix_host.c
+++ b/src/tusb_asix/asix_host.c
@@ -32,11 +32,6 @@ static const struct {
 };
 
 static asixh_interface_t _interfaces[CFG_TUH_ASIX];
-static uint32_t _stats[ASIX_STAT_COUNT];
-
-void tuh_asix_get_stats(uint32_t stats[ASIX_STAT_COUNT]) {
-  memcpy(stats, _stats, sizeof(_stats));
-}
 
 TU_ATTR_ALWAYS_INLINE static inline asixh_interface_t *get_interface(uint8_t dev_addr) {
   TU_VERIFY(dev_addr <= CFG_TUH_DEVICE_MAX, NULL);
@@ -383,8 +378,8 @@ bool tuh_asix_receive(uint8_t dev_addr, uint8_t ep) {
   TU_VERIFY(itf, 0);
   
   TU_VERIFY(usbh_edpt_claim(dev_addr, itf->ep[ep]), false);
-  uint8_t *buf = (ep==0)?itf->ep0in_buf:itf->ep1in_buf;
-  uint16_t len = (ep==0)?sizeof(itf->ep0in_buf):sizeof(itf->ep1in_buf);
+  uint8_t *buf = (ep==0)?itf->ep0in_buf:itf->ep1in_buf[itf->rx_buf_idx];
+  uint16_t len = (ep==0)?sizeof(itf->ep0in_buf):sizeof(itf->ep1in_buf[0]);
   
   if(!usbh_edpt_xfer(dev_addr, itf->ep[ep], buf, len)) {
     usbh_edpt_release(dev_addr, itf->ep[ep]);
@@ -415,10 +410,8 @@ static bool asix_start_tx(asixh_interface_t *itf, uint8_t *buf, uint16_t len) {
   TU_VERIFY(usbh_edpt_claim(itf->dev_addr, itf->ep[2]), false);
   if(!usbh_edpt_xfer(itf->dev_addr, itf->ep[2], buf, len)) {
     usbh_edpt_release(itf->dev_addr, itf->ep[2]);
-    _stats[ASIX_STAT_TX_START_FAIL]++;
     return false;
   }
-  _stats[ASIX_STAT_TX_STARTED]++;
   return true;
 }
 
@@ -440,14 +433,12 @@ static void asix_start_next_tx(asixh_interface_t *itf) {
 
 static void asix_queue_tx(asixh_interface_t *itf, const uint8_t *data, uint16_t len) {
   if(itf->tx_count >= CFG_TUH_ASIX_TX_QUEUE_DEPTH) {
-    _stats[ASIX_STAT_TX_QUEUE_FULL]++;
     return;
   }
 
   uint8_t idx = (uint8_t)((itf->tx_head + itf->tx_count) % CFG_TUH_ASIX_TX_QUEUE_DEPTH);
   itf->tx_len[idx] = asix_prepare_tx(itf->tx_queue[idx], data, len, itf->ep_size[2]);
   itf->tx_count++;
-  _stats[ASIX_STAT_TX_QUEUED]++;
 }
 
 bool asixh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes) {
@@ -459,13 +450,9 @@ bool asixh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint
   asixh_interface_t *itf = get_interface(dev_addr);
   TU_VERIFY(itf, false);
 
-  uint8_t *buf = (number==1)?itf->ep0in_buf:itf->ep1in_buf;
+  uint8_t *buf = (number==1)?itf->ep0in_buf:itf->ep1in_buf[itf->rx_buf_idx];
   
   if(dir == TUSB_DIR_OUT && ep_addr == itf->ep[2]) {
-    if(result == XFER_RESULT_SUCCESS)
-      _stats[ASIX_STAT_TX_DONE]++;
-    else
-      _stats[ASIX_STAT_TX_START_FAIL]++;
     asix_start_next_tx(itf);
     return true;
   }
@@ -492,19 +479,53 @@ bool asixh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint
     
     // ep 2 is bulk data in
     if(number == 2) {
-      _stats[ASIX_STAT_RX_XFERS]++;
+      // switch to the other buffer and re-arm the bulk endpoint right away so
+      // the USB link keeps receiving while we still parse/hand off this buffer
+      itf->rx_buf_idx ^= 1;
+      tuh_asix_receive(dev_addr, 1);
+
       uint32_t offset = 0;
+
+      // finish reassembling a frame whose payload was split across the
+      // previous bulk-in transfer and this one (AX88772 does this whenever
+      // a frame doesn't fit in the remaining space of a 2048-byte transfer)
+      if(itf->rx_carry_need) {
+        uint16_t need = itf->rx_carry_need - itf->rx_carry_have;
+        uint16_t take = (xferred_bytes < need) ? (uint16_t)xferred_bytes : need;
+        memcpy(itf->rx_carry_buf + itf->rx_carry_have, buf, take);
+        itf->rx_carry_have += take;
+        offset = take;
+
+        if(itf->rx_carry_have == itf->rx_carry_need) {
+          if(itf->netif.input) {
+            struct pbuf* p = pbuf_alloc(PBUF_RAW, itf->rx_carry_need, PBUF_POOL);
+            if(p && pbuf_take(p, itf->rx_carry_buf, itf->rx_carry_need) == ERR_OK) {
+              if (itf->netif.input(p, &(itf->netif)) != ERR_OK)
+                pbuf_free(p);
+            } else if(p) {
+              pbuf_free(p);
+            }
+          }
+          itf->rx_carry_need = 0;
+          itf->rx_carry_have = 0;
+        }
+        // else: frame still incomplete, nothing else usable in this transfer
+      }
+
       while(xferred_bytes - offset >= 4) {
         uint16_t len = (buf[offset + 0] + 256*buf[offset + 1]) & 0x7ff;
         uint16_t len_crc = buf[offset + 2] + 256*buf[offset + 3];
         if(!len || len != ((0xffff ^ len_crc) & 0x7ff)) {
-          _stats[ASIX_STAT_RX_BAD_HEADER]++;
           break;
         }
         offset += 4;
 
         if(xferred_bytes - offset < len) {
-          _stats[ASIX_STAT_RX_TRUNCATED]++;
+          // payload continues in the next bulk-in transfer; stash what we
+          // have and finish it above once the rest arrives
+          itf->rx_carry_have = (uint16_t)(xferred_bytes - offset);
+          itf->rx_carry_need = len;
+          memcpy(itf->rx_carry_buf, buf + offset, itf->rx_carry_have);
           break;
         }
 
@@ -515,19 +536,13 @@ bool asixh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint
           if(p && pbuf_take(p, buf+offset, len) == ERR_OK) {
             if (itf->netif.input(p, &(itf->netif)) != ERR_OK)
               pbuf_free(p);
-            _stats[ASIX_STAT_RX_FRAMES]++;
           } else if(p) {
             pbuf_free(p);
-            _stats[ASIX_STAT_RX_PBUF_FAIL]++;
-          } else {
-            _stats[ASIX_STAT_RX_PBUF_FAIL]++;
           }
         }
 
         offset += len;
       }
-      // receive next packet
-      tuh_asix_receive(dev_addr, 1);
     }
   }
   

--- a/src/tusb_asix/asix_host.h
+++ b/src/tusb_asix/asix_host.h
@@ -25,20 +25,6 @@
 #endif
 #endif
 
-typedef enum {
-  ASIX_STAT_RX_XFERS,
-  ASIX_STAT_RX_FRAMES,
-  ASIX_STAT_RX_BAD_HEADER,
-  ASIX_STAT_RX_TRUNCATED,
-  ASIX_STAT_RX_PBUF_FAIL,
-  ASIX_STAT_TX_STARTED,
-  ASIX_STAT_TX_QUEUED,
-  ASIX_STAT_TX_QUEUE_FULL,
-  ASIX_STAT_TX_START_FAIL,
-  ASIX_STAT_TX_DONE,
-  ASIX_STAT_COUNT
-} asix_stat_t;
-
 typedef struct {
   uint8_t dev_addr;
   struct netif netif;
@@ -60,7 +46,16 @@ typedef struct {
   uint16_t ep_size[3];
   
   uint8_t ep0in_buf[8];
-  uint8_t ep1in_buf[CFG_TUH_ASIX_EP_BUFSIZE];
+  // ping-pong buffers for bulk IN: one is handed to lwIP/pbuf while the
+  // other is already queued for the next USB transfer
+  uint8_t ep1in_buf[2][CFG_TUH_ASIX_EP_BUFSIZE];
+  uint8_t rx_buf_idx;
+  // a frame's header/CRC is never split across transfers, but the AX88772
+  // does split an oversized frame's payload across two bulk-in transfers;
+  // this reassembles that continuation instead of misparsing it as a header
+  uint8_t rx_carry_buf[CFG_TUH_ASIX_EP_BUFSIZE];
+  uint16_t rx_carry_have;
+  uint16_t rx_carry_need;
   uint8_t epout_buf[CFG_TUH_ASIX_EP_BUFSIZE];
   uint8_t tx_queue[CFG_TUH_ASIX_TX_QUEUE_DEPTH][CFG_TUH_ASIX_EP_BUFSIZE];
   uint16_t tx_len[CFG_TUH_ASIX_TX_QUEUE_DEPTH];
@@ -73,7 +68,6 @@ extern usbh_class_driver_t const usbh_asix_driver;
 void tuh_asix_umount_cb(asixh_interface_t *asix_itf);
 void tuh_asix_mount_cb(asixh_interface_t *asix_itf);
 void tuh_asix_transmit(struct netif *netif, uint8_t *data, uint16_t len);
-void tuh_asix_get_stats(uint32_t stats[ASIX_STAT_COUNT]);
    
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* speed-up Pico USB LAN dongle transfer speed to ~ 50 kbyte/s on a RP2350
(optimized for PIO USB use case)